### PR TITLE
Support for relayed and routed mode on room creation

### DIFF
--- a/src/daily.ts
+++ b/src/daily.ts
@@ -11,6 +11,12 @@ interface DailyRoomData {
   url: string;
 }
 
+interface DailyRoomProperties {
+  start_video_off: boolean;
+  start_audio_off: boolean;
+  sfu_switchover: number;
+}
+
 export interface Domain {
   domainID: string;
 }
@@ -26,16 +32,23 @@ export interface DailyTokenPayload {
 const dailyAPIDomain = "daily.co";
 const dailyAPIURL = `https://api.${dailyAPIDomain}/v1`;
 
-export async function createRoom(apiKey: string): Promise<DailyRoomData> {
+export async function createRoom(
+  apiKey: string,
+  forceSFU = false
+): Promise<DailyRoomData> {
   const req = {
     // TODO: find out if OT sessions have a default
     // expiry time or any other default options that map
     // to Daily rooms.
-    properties: {
+    properties: <DailyRoomProperties>{
       start_audio_off: false,
       start_video_off: false,
     },
   };
+
+  if (forceSFU) {
+    req.properties.sfu_switchover = 0.5;
+  }
 
   // Prepare our headers, containing our Daily API key
   const headers = {

--- a/src/index.ts
+++ b/src/index.ts
@@ -239,12 +239,12 @@ class OpenTokClass {
 
   // createSession() creates a Daily room and wrangles it
   // into an OpenTok session object
-  createSession(_opts: OTOptions, callback: Callback) {
-    createRoom(this.apiKey)
+  createSession(opts: OTOptions, callback: Callback) {
+    createRoom(this.apiKey, opts.mediaMode === "routed")
       .then((room) => {
         const session = {
           sessionId: room.url,
-          mediaMode: "routed",
+          mediaMode: opts.mediaMode,
           archiveMode: "manual",
           ot: this,
         };


### PR DESCRIPTION
This PR adds support for OpenTok's routed mode by setting our Daily room SFU switchover to 0.5 if this mode is requested by the caller.