### PR TITLE
Include OT "connection data" in generated token payload

### DIFF
--- a/src/daily.ts
+++ b/src/daily.ts
@@ -139,7 +139,7 @@ export function getMeetingToken(
   if (opts?.data) {
     const data = opts?.data;
     if (data.length > 1024) {
-      throw new Error("Token data be a string with maximum length 1024");
+      throw new Error("Token data must have a maximum length 1024");
     }
     payload.otcd = data;
   }

--- a/src/daily.ts
+++ b/src/daily.ts
@@ -27,6 +27,7 @@ export interface DailyTokenPayload {
   exp: number;
   o: boolean;
   iat: number;
+  otcd: string;
 }
 
 const dailyAPIDomain = "daily.co";
@@ -133,6 +134,14 @@ export function getMeetingToken(
       );
     }
     payload.exp = exp;
+  }
+
+  if (opts?.data) {
+    const data = opts?.data;
+    if (data.length > 1024) {
+      throw new Error("Token data be a string with maximum length 1024");
+    }
+    payload.otcd = data;
   }
 
   const role = opts?.role;

--- a/src/tests/daily.test.ts
+++ b/src/tests/daily.test.ts
@@ -59,4 +59,34 @@ describe("Daily meeting token retrieval tests", () => {
     const gotPayload = <DailyTokenPayload>jwt.decode(gotToken);
     expect(gotPayload).toStrictEqual(wantPayload);
   });
+
+  test("Success with custom data", () => {
+    const secret = "very-very-secret";
+    const roomURL = "https://mydomain.daily.co/roomname";
+
+    // Freeze the
+    const now = Date.now();
+    jest.spyOn(Date, "now").mockImplementation(() => now);
+
+    const domainID = "domainID";
+    const data = "somekey=somevalue;someotherkey=someothervalue;";
+    const wantPayload = <DailyTokenPayload>{
+      r: "roomname",
+      d: domainID,
+      // exp should be the default, 24 hours
+      exp: Math.floor(now / 1000) + 3600,
+      o: false,
+      iat: Math.floor(now / 1000),
+      otcd: data,
+    };
+
+    const opts = {
+      domainID,
+      data,
+    };
+
+    const gotToken = getMeetingToken(secret, roomURL, opts);
+    const gotPayload = <DailyTokenPayload>jwt.decode(gotToken);
+    expect(gotPayload).toStrictEqual(wantPayload);
+  });
 });

--- a/src/tests/daily.test.ts
+++ b/src/tests/daily.test.ts
@@ -7,7 +7,7 @@ describe("Daily meeting token retrieval tests", () => {
     const secret = "very-very-secret";
     const roomURL = "https://mydomain.daily.co/roomname";
 
-    // Freeze the
+    // Freeze the time
     const now = Date.now();
     jest.spyOn(Date, "now").mockImplementation(() => now);
 
@@ -64,7 +64,7 @@ describe("Daily meeting token retrieval tests", () => {
     const secret = "very-very-secret";
     const roomURL = "https://mydomain.daily.co/roomname";
 
-    // Freeze the
+    // Freeze the time
     const now = Date.now();
     jest.spyOn(Date, "now").mockImplementation(() => now);
 


### PR DESCRIPTION
This PR takes the existing "data" field in OT's `TokenOptions`, which would usually be encoded as `connection_data` into OT's own token format and sent back to the client. In our case, this adds it to the JWT payload as an `otcd` (OpenTok connection data) claim. 

The length check there matches current OT behavior.

As a followup, the client shim may need to take this information from the JWT payload once it retrieves the token and send it as part of the `"connectionCreated"` event.

