### PR TITLE
Allow passing Daily token payload into `generateToken()`

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,28 +11,30 @@ npm install daily-opentok-node
 When requiring the library in your project, change the following line:
 
 ```typescript
-const OpenTok = require('opentok');
+const OpenTok = require("opentok");
 ```
 
 to this:
 
 ```typescript
-const OpenTok = require('daily-opentok-node');
+const OpenTok = require("daily-opentok-node");
 ```
 
 Also when creating a new `OT` object, replace any occurrences of the following code:
 
 ```typescript
-const OT = new OpenTok('openTokAPIKey', 'openTokAPISecret');
+const OT = new OpenTok("openTokAPIKey", "openTokAPISecret");
 ```
 
 with this:
 
 ```typescript
-const OT = new OpenTok('dailyApiKey');
+const OT = new OpenTok("dailyApiKey");
 await OT.getDomainID();
 ```
 
 <aside>
+
 💡 Note: Daily’s authentication flow is a bit different than the OpenTok flow, so we have to include a call to `getDomainID()`.
+
 </aside>

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,7 +18,12 @@ import {
   Token,
   TokenOptions,
 } from "opentok";
-import { createRoom, getMeetingToken, getDomainID } from "./daily";
+import {
+  createRoom,
+  getMeetingToken,
+  getDomainID,
+  DailyTokenPayload,
+} from "./daily";
 
 function notImplemented(): never {
   throw new Error("Method not implemented.");
@@ -256,16 +261,26 @@ class OpenTokClass {
   }
 
   // generateToken() returns a self-signed Daily meeting token
-  generateToken(sessionID: string, options?: TokenOptions): string {
-    if (!this.domainID) {
+  generateToken(
+    sessionID: string,
+    options?: TokenOptions,
+    dailyPayload?: DailyTokenPayload
+  ): string {
+    // The user may pass a domain ID with their Daily payload
+    if (!dailyPayload?.d && !this.domainID) {
       throw new Error(
         "Daily domain ID is missing. Did you call getDomainID() first?"
       );
     }
-    return getMeetingToken(this.apiKey, sessionID, {
-      ...options,
-      domainID: this.domainID,
-    });
+    return getMeetingToken(
+      this.apiKey,
+      sessionID,
+      {
+        ...options,
+        domainID: this.domainID,
+      },
+      dailyPayload
+    );
   }
 }
 


### PR DESCRIPTION
This PR allows the caller to pass a `DailyPayload` object to the OT `generateToken()` function. Everything in the explicitly passed Daily payload takes priority over other options.